### PR TITLE
Disable vec constructor from non-compatible components

### DIFF
--- a/include/gml/vec.hpp
+++ b/include/gml/vec.hpp
@@ -26,6 +26,12 @@ namespace gml {
  */
 template <typename T, int N>
 class vec {
+private:
+  template<typename First, typename... Args>
+  struct _first_arg { using type = First; };
+  template<typename... Args>
+  using _first_t = typename _first_arg<Args...>::type;
+
 public:
 
 	static_assert(N > 0, "N must be greater than zero!");
@@ -52,7 +58,7 @@ public:
 	/// Initializes components from N values directly.
 	template <
 		typename... Args,
-		typename std::enable_if<N == sizeof...(Args), int>::type = 0
+		typename std::enable_if<N == sizeof...(Args) && std::is_convertible<_first_t<Args...>, T>::value, int>::type = 0
 	>
 	vec(const Args&... args) :
 		data_{ args... }

--- a/include/gml/vec.hpp
+++ b/include/gml/vec.hpp
@@ -27,10 +27,13 @@ namespace gml {
 template <typename T, int N>
 class vec {
 private:
-  template<typename First, typename... Args>
-  struct _first_arg { using type = First; };
-  template<typename... Args>
-  using _first_t = typename _first_arg<Args...>::type;
+  template<typename...>
+  struct _all_convertible : std::true_type {};
+  template<typename U, typename First, typename... Args>
+  struct _all_convertible<U, First, Args...> {
+    static constexpr bool value = std::is_convertible<First, U>::value &&
+      _all_convertible<U, Args...>::value;
+  };
 
 public:
 
@@ -58,7 +61,7 @@ public:
 	/// Initializes components from N values directly.
 	template <
 		typename... Args,
-		typename std::enable_if<N == sizeof...(Args) && std::is_convertible<_first_t<Args...>, T>::value, int>::type = 0
+		typename std::enable_if<N == sizeof...(Args) && _all_convertible<T, Args...>::value, int>::type = 0
 	>
 	vec(const Args&... args) :
 		data_{ args... }


### PR DESCRIPTION
It might seem strange to use 1-element vectors, but I have a template class for the 2- and 3-element case, so I thought I'd re-use the code also for scalar case.

Anyway, my problem reduces to this code example:

```cpp
#include "gml/vec.hpp"

struct myvec : gml::vec<double, 1> {};

int main()
{
  myvec a;
  gml::vec<double, 1> b(a);  // ERROR
  auto c = static_cast<gml::vec<double, 1>>(a);  // ERROR
}
```

Which causes this compiler error:

```
gml/vec.hpp:58:18: error: cannot convert ‘const myvec’ to ‘double’ in initialization
   data_{ args... }
```

It works fine when changing all occurrences of `1` to e.g. `2`. 

The problem seems to be this constructor:

https://github.com/ilmola/gml/blob/fe4627f7b35a04693cf38d6f564885fa2b183b4f/include/gml/vec.hpp#L52-L61

... which seems to be a better match in my case (for `N == 1`) than the default copy constructor (which I would like to be called), but of course it fails because the types are incompatible.

I tried to solve this by checking if the type is convertible.
This works for me but it may not be the best way to solve this.
It would probably be enough to only check this if `N == 1`.