### PR TITLE
Add preprocessor check to exclude string and stream code.

### DIFF
--- a/include/gml/mat.hpp
+++ b/include/gml/mat.hpp
@@ -9,9 +9,11 @@
 #include <assert.h>
 #include <cmath>
 #include <cstdint>
+#ifndef GML_EMBEDDED
 #include <iostream>
 #include <sstream>
 #include <string>
+#endif
 #include <tuple>
 
 #include "vec.hpp"
@@ -265,6 +267,7 @@ mat<T, C, R> operator*(const T& a, const mat<T, C, R>& m) {
 	return temp;
 }
 
+#ifndef GML_EMBEDDED
 
 /// Prints the matrix to a stream inside brackets columns separated by a comma.
 template <typename T, int C, int R>
@@ -301,6 +304,7 @@ std::string to_string(const mat<T, C, R>& m) {
 	return ss.str();
 }
 
+#endif
 
 /// Returns the transpose of the matrix.
 template <typename T, int C, int R>

--- a/include/gml/quaternion.hpp
+++ b/include/gml/quaternion.hpp
@@ -9,9 +9,11 @@
 #include <assert.h>
 #include <cmath>
 #include <cstdint>
+#ifndef GML_EMBEDDED
 #include <iostream>
 #include <sstream>
 #include <string>
+#endif
 #include <tuple>
 
 #include "vec.hpp"
@@ -208,6 +210,8 @@ quaternion<T> operator-(const vec<T, 3>& v, const quaternion<T>& q) {
 }
 
 
+#ifndef GML_EMBEDDED
+
 /// Write a quaternion to a stream inside brackets parts separated by a comma.
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const quaternion<T>& q) {
@@ -233,6 +237,8 @@ std::string to_string(const quaternion<T>& q) {
 	ss << q;
 	return ss.str();
 }
+
+#endif
 
 
 /// Returns the squared magnitude of the quaternion q

--- a/include/gml/vec.hpp
+++ b/include/gml/vec.hpp
@@ -9,10 +9,12 @@
 #include <assert.h>
 #include <cmath>
 #include <cstdint>
-#include <iostream>
 #include <limits>
+#ifndef GML_EMBEDDED
+#include <iostream>
 #include <sstream>
 #include <string>
+#endif
 #include <utility>
 
 namespace gml {
@@ -346,6 +348,8 @@ vec<T, N> operator/(const T& a, const vec<T, N>& v) {
 }
 
 
+#ifndef GML_EMBEDDED
+
 /// Prints the vector to a stream inside brackets components separated by a comma.
 template <typename T, int N>
 std::ostream& operator<<(std::ostream& os, const vec<T, N>& v) {
@@ -380,6 +384,8 @@ std::string to_string(const vec<T, N>& v) {
 	ss << v;
 	return ss.str();
 }
+
+#endif
 
 
 /// Dot products of vectors v1 and v2


### PR DESCRIPTION
Although this is a header only library, the mere act of including iostream & co ends up needing additional symbols at link time that make it unable to be used on systems lacking the full runtime support (specifically, it does not work with the latest few versions of the ARM gcc embedded toolchain with -nostdlib).